### PR TITLE
Issue 5

### DIFF
--- a/lib/rules/no-slow-query.js
+++ b/lib/rules/no-slow-query.js
@@ -10,35 +10,109 @@ var includes = require("lodash.includes");
 var NO_SLOW_QUERY_CONSTS = require("../consts/no-slow-query");
 
 
-var SLOW_QUERY_FUNCTIONS_PARAMS_TYPES_CHECKER = NO_SLOW_QUERY_CONSTS.PARAMS_TYPES_CHECKER;
+// var SLOW_QUERY_FUNCTIONS_PARAMS_TYPES_CHECKER = NO_SLOW_QUERY_CONSTS.PARAMS_TYPES_CHECKER;
 var SLOW_QUERY_FUNCTIONS_NAME = NO_SLOW_QUERY_CONSTS.FUNCTIONS_NAME;
 
 
 module.exports = function(context) {
+    /** @type {Object[]} Contains nodes of declaration of `new Parse.Query` */
+    var VARS;
+
+    // @todo Support of callee which are not member expression
+    function getRootOfTypeOfCallExpression(node) {
+        if (node.type !== "CallExpression") {
+            throw new TypeError("node is not a CallExpression");
+        }
+
+        var callee = node.callee;
+
+        if (callee.type !== "MemberExpression") return null;
+
+        if (callee.object.type === "CallExpression") {
+            return getRootOfTypeOfCallExpression(callee.object);
+        } else if (callee.type) {
+            return callee.object;
+        }
+
+        return null;
+    }
+
+    function isNewExpressionOfParseQuery(node) {
+        var callee = node.callee;
+
+        if (!callee) return false;
+        if (callee.type !== "MemberExpression") return false;
+        if (!callee.object) return false;
+        if (callee.object.type !== "Identifier") return false;
+        if (callee.object.name !== "Parse") return false;
+        if (!callee.property) return false;
+        if (callee.property.type !== "Identifier") return false;
+        if (callee.property.name !== "Query") return false;
+
+        return true;
+    }
+
 
     return {
+        "Program": function() {
+            VARS = [];
+        },
+
+        "NewExpression": function(node) {
+            var callee = node.callee;
+
+            if (callee.type !== "MemberExpression") return;
+            if (!callee.object) return;
+            if (callee.object.type !== "Identifier") return;
+            if (callee.object.name !== "Parse") return;
+            if (!callee.property) return;
+            if (callee.property.type !== "Identifier") return;
+            if (callee.property.name !== "Query") return;
+
+            var parent = node.parent;
+            if (parent && parent.type === "VariableDeclarator") {
+                VARS.push(parent);
+            }
+        },
+
         "CallExpression": function(node) {
-            var args = node.arguments;
-            var object = node.callee.object;
-            var property = node.callee.property;
+            var callee = node.callee;
 
+            if (!callee) return;
+            if (callee.type !== "MemberExpression") return;
+            if (!callee.property) return;
+            if (callee.property.type !== "Identifier") return;
+            if (!includes(SLOW_QUERY_FUNCTIONS_NAME, callee.property.name)) return;
 
-            if (property &&
-                args &&
-                property.type === "Identifier" &&
-                !(object && object.value)) {
+            var fnName = callee.property.name;
+            var topNode = getRootOfTypeOfCallExpression(node);
 
+            if (!topNode) return;
 
-                var fnName = property.name;
-                var paramsTypesChecker = SLOW_QUERY_FUNCTIONS_PARAMS_TYPES_CHECKER[fnName];
+            switch(topNode.type) {
+            // Invoked directly on `new Parse.Query` object
+            case "NewExpression":
+                if (isNewExpressionOfParseQuery(topNode)) {
+                    context.report(callee.property, `\`Parse.Query#${fnName}()\` it's a slow query that can cause timeouts`);
+                }
+                return;
 
+            // Invoked by variable of `Parse.Query` object
+            // NOTE: - it only iterates on variables names
+            //       - id doesn't check for scoping, and remove irrelevant variables
+            case "Identifier":
+                if (VARS.some(function(variable) {
+                    switch(variable.type) {
+                    case "VariableDeclarator":
+                        return (
+                            variable.id.type === "Identifier" &&
+                            variable.id.name === topNode.name
+                        );
+                    }
 
-                if (// Is function name is of slow query
-                    includes(SLOW_QUERY_FUNCTIONS_NAME, fnName) &&
-                    // Type checker of arguments
-                    paramsTypesChecker(args)) {
-
-                    context.report(property, `\`Parse.Query#${fnName}()\` it's a slow query that can cause timeouts`);
+                    return false;
+                })) {
+                    context.report(callee.property, `\`Parse.Query#${fnName}()\` it's a slow query that can cause timeouts`);
                 }
             }
         }

--- a/tests/lib/rules/no-slow-query.js
+++ b/tests/lib/rules/no-slow-query.js
@@ -26,6 +26,11 @@ ruleTester.run("lib/rules/no-slow-query", rule, {
             `
         }, {
             code: `
+                hi();
+                doesNotExist('test');
+            `
+        }, {
+            code: `
                 someObject.exists();
             `
         }, {
@@ -40,6 +45,11 @@ ruleTester.run("lib/rules/no-slow-query", rule, {
             code: `
                 _.exists('test');
             `
+        }, {
+            code: `
+                // ok when there is no assignment to a new Parse.Query
+                query.exists('test');
+            `
         }
     ],
 
@@ -48,6 +58,16 @@ ruleTester.run("lib/rules/no-slow-query", rule, {
         {
             code: `
                 new Parse.Query("Item")
+                    .doesNotExist("someKey");
+            `,
+            errors: [{
+                message: "`Parse.Query#doesNotExist()` it's a slow query that can cause timeouts",
+                type: "Identifier"
+            }]
+        }, {
+            code: `
+                new Parse.Query("Item")
+                    .bullshit()
                     .doesNotExist("someKey");
             `,
             errors: [{

--- a/tests/lib/rules/no-slow-query.js
+++ b/tests/lib/rules/no-slow-query.js
@@ -36,6 +36,10 @@ ruleTester.run("lib/rules/no-slow-query", rule, {
             code: `
                 'test'.exists('test');
             `
+        }, {
+            code: `
+                _.exists('test');
+            `
         }
     ],
 
@@ -51,92 +55,101 @@ ruleTester.run("lib/rules/no-slow-query", rule, {
                 type: "Identifier"
             }]
         }, {
-            code: `query.doesNotExist(someVar);`,
+            code: `
+                var query = new Parse.Query("Item");
+                query.doesNotExist("someKey");
+            `,
             errors: [{
                 message: "`Parse.Query#doesNotExist()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.doesNotExist('someKey');`,
+            code: `new Parse.Query("Item").doesNotExist(someVar);`,
             errors: [{
                 message: "`Parse.Query#doesNotExist()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.doesNotMatchKeyInQuery('someKey', 'someKeyKey', new Parse.Query('Item'));`,
+            code: `new Parse.Query("Item").doesNotExist('someKey');`,
+            errors: [{
+                message: "`Parse.Query#doesNotExist()` it's a slow query that can cause timeouts",
+                type: "Identifier"
+            }]
+        }, {
+            code: `new Parse.Query("Item").doesNotMatchKeyInQuery('someKey', 'someKeyKey', new Parse.Query('Item'));`,
             errors: [{
                 message: "`Parse.Query#doesNotMatchKeyInQuery()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.doesNotMatchQuery('someKey', new Parse.Query('Item'));`,
+            code: `new Parse.Query("Item").doesNotMatchQuery('someKey', new Parse.Query('Item'));`,
             errors: [{
                 message: "`Parse.Query#doesNotMatchQuery()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.endsWith('someKey', 'someValue');`,
+            code: `new Parse.Query("Item").endsWith('someKey', 'someValue');`,
             errors: [{
                 message: "`Parse.Query#endsWith()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.exists('someKey');`,
+            code: `new Parse.Query("Item").exists('someKey');`,
             errors: [{
                 message: "`Parse.Query#exists()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
 
         }, {
-            code: `query.matches('someKey', /regex/);`,
+            code: `new Parse.Query("Item").matches('someKey', /regex/);`,
             errors: [{
                 message: "`Parse.Query#matches()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.matches('someKey', /regex/i);`,
+            code: `new Parse.Query("Item").matches('someKey', /regex/i);`,
             errors: [{
                 message: "`Parse.Query#matches()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.matches('someKey', new RegExp("regex"));`,
+            code: `new Parse.Query("Item").matches('someKey', new RegExp("regex"));`,
             errors: [{
                 message: "`Parse.Query#matches()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.matches('someKey', new RegExp("regex"), "i");`,
+            code: `new Parse.Query("Item").matches('someKey', new RegExp("regex"), "i");`,
             errors: [{
                 message: "`Parse.Query#matches()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.notContainedIn('someKey', []);`,
+            code: `new Parse.Query("Item").notContainedIn('someKey', []);`,
             errors: [{
                 message: "`Parse.Query#notContainedIn()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.notContainedIn('someKey', 1 ? [] : []);`,
+            code: `new Parse.Query("Item").notContainedIn('someKey', 1 ? [] : []);`,
             errors: [{
                 message: "`Parse.Query#notContainedIn()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.notContainedIn('someKey', [1, 2, 3]);`,
+            code: `new Parse.Query("Item").notContainedIn('someKey', [1, 2, 3]);`,
             errors: [{
                 message: "`Parse.Query#notContainedIn()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.notEqualTo('someKey', 'hello');`,
+            code: `new Parse.Query("Item").notEqualTo('someKey', 'hello');`,
             errors: [{
                 message: "`Parse.Query#notEqualTo()` it's a slow query that can cause timeouts",
                 type: "Identifier"
             }]
         }, {
-            code: `query.startsWith('someKey', 'hello');`,
+            code: `new Parse.Query("Item").startsWith('someKey', 'hello');`,
             errors: [{
                 message: "`Parse.Query#startsWith()` it's a slow query that can cause timeouts",
                 type: "Identifier"


### PR DESCRIPTION
- alert only on direct use of new Parse.Query
- or a variable that was assigned to a new Parse.Query declaration
